### PR TITLE
fix epoch overflow in log parsing

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -270,7 +270,7 @@ unsigned long long printQubicLog(uint8_t* logBuffer, int bufferSize, uint64_t fr
     }
     while (logBuffer < end){
         // basic info
-        uint16_t epoch = *((unsigned char*)(logBuffer));
+        uint16_t epoch = *((unsigned short*)(logBuffer));
         uint32_t tick = *((unsigned int*)(logBuffer + 2));
         uint32_t tmp = *((unsigned int*)(logBuffer + 6));
         uint64_t logId = *((unsigned long long*)(logBuffer + 10));


### PR DESCRIPTION
Fix epoch overflow in log parsing
The parser was reading the epoch field as a single byte instead of 2 bytes, causing overflow when epoch values exceeded 255. This patch fixes the issue by changing the epoch field reading to use the correct 2-byte data type (unsigned short), ensuring epoch values are displayed correctly.